### PR TITLE
Add new functionality to list details of the latest 3 matches

### DIFF
--- a/clientapp/src/components/MatchDetails/index.tsx
+++ b/clientapp/src/components/MatchDetails/index.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { fetchMatchDetails } from '@/services/api.services';
+
+interface MatchDetailsProps {
+  encryptedPUUID: string;
+}
+
+const MatchDetails: React.FC<MatchDetailsProps> = ({ encryptedPUUID }) => {
+  const [matches, setMatches] = useState<any[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchMatches = async () => {
+      try {
+        const data = await fetchMatchDetails(encryptedPUUID);
+        setMatches(data);
+        setLoading(false);
+      } catch (err: any) {
+        setError(err.message);
+        setLoading(false);
+      }
+    };
+
+    fetchMatches();
+  }, [encryptedPUUID]);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  return (
+    <div>
+      <h2>Latest 3 Matches</h2>
+      <ul>
+        {matches.map((match, index) => (
+          <li key={index}>
+            <p>Match ID: {match.matchId}</p>
+            <p>Champion: {match.champion}</p>
+            <p>Role: {match.role}</p>
+            <p>Lane: {match.lane}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MatchDetails;

--- a/clientapp/src/components/SummonerProfile/SummonerDisplay.tsx
+++ b/clientapp/src/components/SummonerProfile/SummonerDisplay.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import ChampionMasteryCard from '../ChampionMasteryCard';
 import TopChampionOptions from './TopChampionOptions';
+import MatchDetails from '../MatchDetails';
 
 const SummonerDisplay: React.FC<{
     encryptedPUUID: string;
@@ -18,6 +19,9 @@ const SummonerDisplay: React.FC<{
         />
         {showTopChampions && encryptedPUUID && (
             <ChampionMasteryCard encryptedPUUID={encryptedPUUID} count={count} />
+        )}
+        {encryptedPUUID && (
+            <MatchDetails encryptedPUUID={encryptedPUUID} />
         )}
     </div>
 );

--- a/clientapp/src/services/api.services.ts
+++ b/clientapp/src/services/api.services.ts
@@ -20,3 +20,11 @@ export async function fetchChampionMasteries(encryptedPUUID: string, count: numb
     const res = await fetch(`${backend_api_url}/champion-mastery/${encryptedPUUID}?count=${count}`);
     return await res.json();
 }
+
+export async function fetchMatchDetails(encryptedPUUID: string) {
+    const res = await fetch(`${backend_api_url}/match/${encryptedPUUID}`);
+    if (!res.ok) {
+        throw new Error(res.statusText);
+    }
+    return await res.json();
+}

--- a/serverapp/controllers/match.controller.ts
+++ b/serverapp/controllers/match.controller.ts
@@ -1,0 +1,13 @@
+import { GetLatestMatchesByPUUID } from "../services";
+
+const GetLatestMatches = async (req: any, res: any) : Promise<any> => {
+    const { encryptedPUUID } = req.params;
+
+    const results: any = await GetLatestMatchesByPUUID(encryptedPUUID);
+
+    return res.status(results.status).json(results);
+}
+
+export default { 
+    GetLatestMatches
+};

--- a/serverapp/routes/index.ts
+++ b/serverapp/routes/index.ts
@@ -4,8 +4,10 @@ const router = express.Router()
 
 const Summoner = require('./summoner.routes')
 const Champion = require('./champion.routes')
+const Match = require('./match.routes')
 
 router.use('/summoner', Summoner)
 router.use('/champion-mastery', Champion)
+router.use('/match', Match)
 
 module.exports = router

--- a/serverapp/routes/match.routes.ts
+++ b/serverapp/routes/match.routes.ts
@@ -1,0 +1,9 @@
+import MatchController from '../controllers/match.controller';
+
+const express = require('express')
+
+const router = express.Router()
+
+router.get('/:encryptedPUUID', MatchController.GetLatestMatches)
+
+module.exports = router

--- a/serverapp/services/match.services.ts
+++ b/serverapp/services/match.services.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+import { ApiResponse } from '../types/api.response.type'
+import { riot_api_key, riot_match_api_url } from '../api';
+
+export const GetLatestMatchesByPUUID = async (encryptedPUUID: string): Promise<ApiResponse> => {
+    try {
+        const results = await axios.get(`${riot_match_api_url}/matches/by-puuid/${encryptedPUUID}/ids?start=0&count=3&api_key=${riot_api_key}`);
+
+        return {
+            status: 200,
+            success: true,
+            data: results.data,
+        }
+    } catch (error) {
+        console.error('/GetLatestMatchesByPUUID - error', error)
+        return {
+            status: 500,
+            success: false,
+        }
+    }
+}


### PR DESCRIPTION
Add functionality to list details of the latest 3 matches for a given summoner.

* **Client-side changes:**
  - Add `MatchDetails` component in `clientapp/src/components/MatchDetails/index.tsx` to fetch and display the latest 3 matches.
  - Modify `SummonerDisplay` component in `clientapp/src/components/SummonerProfile/SummonerDisplay.tsx` to import and use `MatchDetails` component.
  - Add `fetchMatchDetails` function in `clientapp/src/services/api.services.ts` to fetch match details from the backend.

* **Server-side changes:**
  - Add `match.controller.ts` to handle match-related requests.
  - Add `match.services.ts` to fetch match data from the Riot API.
  - Add `match.routes.ts` to handle match-related routes.
  - Modify `index.ts` in `serverapp/routes` to import and use `match.routes.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ElNahoko/league-summoner-insight-app/pull/1?shareId=d3d15bca-c5ab-4c04-a2fb-e2c0d2b65249).